### PR TITLE
style は teamgenik では使えないため、 class で任意値を使用する方法に修正

### DIFF
--- a/src/pages/index.html
+++ b/src/pages/index.html
@@ -18,11 +18,7 @@
       <div class="p-6">
         <!-- Hero -->
         <div
-          class="h-full border border-white text-gray-600"
-          style="
-            background: linear-gradient(to right, white, transparent),
-              url('../images/not-pot-j8Pfv4nnuyE-unsplash.jpg');
-          "
+          class="h-full border border-white bg-[linear-gradient(to_right,_white,_transparent),url('../src/images/not-pot-j8Pfv4nnuyE-unsplash.jpg')] text-gray-600"
         >
           <p class="mt-16 text-3xl font-bold tracking-wider">kenko</p>
           <p class="my-4 text-3xl font-bold tracking-wider">


### PR DESCRIPTION
CSS の url() で相対パスを使う場合、その起点となるパスは stylesheet のファイルパスになる点に注意。

> Relative URLs, if used, are relative to the URL of the stylesheet (not to the URL of the web page).

ref. https://developer.mozilla.org/en-US/docs/Web/CSS/url

---

`dist/tailwind.css` がパスの起点となるので、相対パスは `dist/../src/images/file` に展開される。
